### PR TITLE
Fix issue with spago (> 0.20.0) complaining about transitive dependences

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -4,8 +4,19 @@ You can edit this file as you like.
 -}
 { name = "halogen-svg"
 , dependencies =
-  [ "halogen"
+  [ "aff"
+  , "console"
+  , "effect"
+  , "halogen"
+  , "halogen-vdom"
+  , "maybe"
+  , "newtype"
+  , "prelude"
   , "psci-support"
+  , "strings"
+  , "unsafe-coerce"
+  , "web-html"
+  , "web-uievents"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/spago.dhall
+++ b/spago.dhall
@@ -14,6 +14,7 @@ You can edit this file as you like.
   , "prelude"
   , "psci-support"
   , "strings"
+  , "typelevel-prelude"
   , "unsafe-coerce"
   , "web-html"
   , "web-uievents"

--- a/src/Halogen/Svg/Attributes.purs
+++ b/src/Halogen/Svg/Attributes.purs
@@ -36,11 +36,24 @@ module Halogen.Svg.Attributes
   , x1, y1
   , x2, y2
   , stroke
+  , stroke_dasharray
+  , stroke_dashoffset
+  , stroke_linecap
+  , stroke_linejoin
+  , stroke_miterlimit
+  , stroke_opacity
   , fill
+  , fillOpacity
   , transform
   , d
   , text_anchor
+  , font_family
   , font_size
+  , font_size_adjust
+  , font_stretch
+  , font_style
+  , font_variant
+  , font_weight
   , dominant_baseline
   , class_
   , classes
@@ -50,6 +63,8 @@ module Halogen.Svg.Attributes
   , orient
   , markerUnits
   , strokeWidth
+  , markerStart
+  , markerMid
   , markerEnd
   , DurationF(..)
   , printDurationF
@@ -71,14 +86,13 @@ module Halogen.Svg.Attributes
 -- Like Halogen.HTML.Properties
 
 import Prelude
+
 import Data.Maybe (Maybe(..), maybe)
 import Data.Newtype (un)
 import Data.String (joinWith, toUpper)
-
-import Halogen.Svg.Core as Core
-
 import Halogen.HTML.Core (Prop, AttrName(AttrName), Namespace(Namespace), ClassName(..))
 import Halogen.HTML.Properties (IProp, attrNS)
+import Halogen.Svg.Core as Core
 import Unsafe.Coerce (unsafeCoerce)
 
 data Color = RGB Int Int Int
@@ -398,8 +412,32 @@ y2 = attr (AttrName "y2") <<< show
 stroke :: forall r i. Maybe Color -> IProp (stroke :: String | r) i
 stroke = attr (AttrName "stroke") <<< printColor
 
+stroke_dasharray :: forall r i. String -> IProp (strokeDasharray :: String | r) i
+stroke_dasharray = attr (AttrName "stroke-dasharray")
+
+stroke_dashoffset :: forall r i. Number -> IProp (strokeDashoffset :: String | r) i
+stroke_dashoffset = attr (AttrName "stroke-dashoffset") <<< show
+
+stroke_linecap :: forall r i. String -> IProp (strokeLinecap :: String | r) i
+stroke_linecap = attr (AttrName "stroke-linecap")
+
+stroke_linejoin :: forall r i. String -> IProp (strokeLinejoin :: String | r) i
+stroke_linejoin = attr (AttrName "stroke-linejoin")
+
+stroke_miterlimit :: forall r i. String -> IProp (strokeMiterlimit :: String | r) i
+stroke_miterlimit = attr (AttrName "stroke-miterlimit")
+
+stroke_opacity :: forall r i. Number -> IProp (strokeOpacity :: String | r) i
+stroke_opacity = attr (AttrName "stroke-opacity") <<< show
+
+strokeWidth :: forall r i. Number -> IProp (strokeWidth :: Number | r) i
+strokeWidth = attr (AttrName "stroke-width") <<< show
+
 fill :: forall r i. Maybe Color -> IProp (fill :: String | r) i
 fill = attr (AttrName "fill") <<< printColor
+
+fillOpacity :: forall r i. Number -> IProp (fillOpacity :: Number | r) i
+fillOpacity = attr (AttrName "fill-opacity") <<< show
 
 transform :: forall r i . Array Transform -> IProp (transform :: String | r) i
 transform = attr (AttrName "transform") <<< joinWith " " <<< map printTransform
@@ -413,8 +451,26 @@ d = attr (AttrName "d") <<< joinWith " " <<< unwrapNewtype
 text_anchor :: forall r i . TextAnchor -> IProp (text_anchor :: String | r) i
 text_anchor = attr (AttrName "text-anchor") <<< printTextAnchor
 
+font_family :: forall r i. String -> IProp (font_family :: String | r) i
+font_family = attr (AttrName "font-family")
+
 font_size :: forall r i. FontSize -> IProp (font_size :: String | r) i
 font_size = attr (AttrName "font-size") <<< show
+
+font_size_adjust :: forall r i. Number -> IProp (font_size_adjust :: String | r) i
+font_size_adjust = attr (AttrName "font-size-adjust") <<< show
+
+font_stretch :: forall r i. String -> IProp (font_stretch :: String | r) i
+font_stretch = attr (AttrName "font-stretch")
+
+font_style :: forall r i. String -> IProp (font_style :: String | r) i
+font_style = attr (AttrName "font-style")
+
+font_variant :: forall r i. String -> IProp (font_variant :: String | r) i
+font_variant = attr (AttrName "font-variant")
+
+font_weight :: forall r i. String -> IProp (font_weight :: String | r) i
+font_weight = attr (AttrName "font-weight")
 
 dominant_baseline :: forall r i . Baseline -> IProp (transform :: String | r) i
 dominant_baseline = attr (AttrName "dominant-baseline") <<< printBaseline
@@ -449,11 +505,15 @@ orient = attr (AttrName "orient") <<< printOrient
 markerUnits :: forall r i. MarkerUnit -> IProp (markerUnits :: String | r) i
 markerUnits = attr (AttrName "markerUnits") <<< printMarkerUnit
 
-strokeWidth :: forall r i. Number -> IProp (strokeWidth :: Number | r) i
-strokeWidth = attr (AttrName "stroke-width") <<< show
+markerStart :: forall r i. String -> IProp (markerStart :: String | r) i
+markerStart = attr (AttrName "marker-start")
+
+markerMid :: forall r i. String -> IProp (markerMid :: String | r) i
+markerMid = attr (AttrName "marker-mid")
 
 markerEnd :: forall r i. String -> IProp (markerEnd :: String | r) i
 markerEnd = attr (AttrName "marker-end")
+
 
 --------------------------------------------------------------------------------
 

--- a/src/Halogen/Svg/Attributes.purs
+++ b/src/Halogen/Svg/Attributes.purs
@@ -451,25 +451,25 @@ d = attr (AttrName "d") <<< joinWith " " <<< unwrapNewtype
 text_anchor :: forall r i . TextAnchor -> IProp (text_anchor :: String | r) i
 text_anchor = attr (AttrName "text-anchor") <<< printTextAnchor
 
-font_family :: forall r i. String -> IProp (fontFamily :: String | r) i
+font_family :: forall r i. String -> IProp (font_family :: String | r) i
 font_family = attr (AttrName "font-family")
 
-font_size :: forall r i. FontSize -> IProp (fontSize :: String | r) i
+font_size :: forall r i. FontSize -> IProp (font_size :: String | r) i
 font_size = attr (AttrName "font-size") <<< show
 
-font_size_adjust :: forall r i. Number -> IProp (fontSizeAdjust :: String | r) i
+font_size_adjust :: forall r i. Number -> IProp (font_size_adjust :: String | r) i
 font_size_adjust = attr (AttrName "font-size-adjust") <<< show
 
-font_stretch :: forall r i. String -> IProp (fontStretch :: String | r) i
+font_stretch :: forall r i. String -> IProp (font_stretch :: String | r) i
 font_stretch = attr (AttrName "font-stretch")
 
-font_style :: forall r i. String -> IProp (fontStyle :: String | r) i
+font_style :: forall r i. String -> IProp (font_style :: String | r) i
 font_style = attr (AttrName "font-style")
 
-font_variant :: forall r i. String -> IProp (fontVariant :: String | r) i
+font_variant :: forall r i. String -> IProp (font_variant :: String | r) i
 font_variant = attr (AttrName "font-variant")
 
-font_weight :: forall r i. String -> IProp (fontWeight :: String | r) i
+font_weight :: forall r i. String -> IProp (font_weight :: String | r) i
 font_weight = attr (AttrName "font-weight")
 
 dominant_baseline :: forall r i . Baseline -> IProp (transform :: String | r) i

--- a/src/Halogen/Svg/Attributes.purs
+++ b/src/Halogen/Svg/Attributes.purs
@@ -451,25 +451,25 @@ d = attr (AttrName "d") <<< joinWith " " <<< unwrapNewtype
 text_anchor :: forall r i . TextAnchor -> IProp (text_anchor :: String | r) i
 text_anchor = attr (AttrName "text-anchor") <<< printTextAnchor
 
-font_family :: forall r i. String -> IProp (font_family :: String | r) i
+font_family :: forall r i. String -> IProp (fontFamily :: String | r) i
 font_family = attr (AttrName "font-family")
 
-font_size :: forall r i. FontSize -> IProp (font_size :: String | r) i
+font_size :: forall r i. FontSize -> IProp (fontSize :: String | r) i
 font_size = attr (AttrName "font-size") <<< show
 
-font_size_adjust :: forall r i. Number -> IProp (font_size_adjust :: String | r) i
+font_size_adjust :: forall r i. Number -> IProp (fontSizeAdjust :: String | r) i
 font_size_adjust = attr (AttrName "font-size-adjust") <<< show
 
-font_stretch :: forall r i. String -> IProp (font_stretch :: String | r) i
+font_stretch :: forall r i. String -> IProp (fontStretch :: String | r) i
 font_stretch = attr (AttrName "font-stretch")
 
-font_style :: forall r i. String -> IProp (font_style :: String | r) i
+font_style :: forall r i. String -> IProp (fontStyle :: String | r) i
 font_style = attr (AttrName "font-style")
 
-font_variant :: forall r i. String -> IProp (font_variant :: String | r) i
+font_variant :: forall r i. String -> IProp (fontVariant :: String | r) i
 font_variant = attr (AttrName "font-variant")
 
-font_weight :: forall r i. String -> IProp (font_weight :: String | r) i
+font_weight :: forall r i. String -> IProp (fontWeight :: String | r) i
 font_weight = attr (AttrName "font-weight")
 
 dominant_baseline :: forall r i . Baseline -> IProp (transform :: String | r) i

--- a/src/Halogen/Svg/Indexed.purs
+++ b/src/Halogen/Svg/Indexed.purs
@@ -1,14 +1,37 @@
 module Halogen.Svg.Indexed where
 
+import Web.UIEvent.KeyboardEvent (KeyboardEvent)
 import Web.UIEvent.MouseEvent (MouseEvent)
 import Web.UIEvent.WheelEvent (WheelEvent)
-import Web.UIEvent.KeyboardEvent (KeyboardEvent)
 
--- Attributes based on Mozilla MDN categories
+{-
+The table below show which groups of attributes apply to which elements. This
+table is compiled by looking up each attribute on MDN
+(e.g., https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke)
+and looking at the list labeled "You can use this attribute with the following
+SVG elements:". Groups are formed from attributes that have the same element
+applicability.
 
-type CoreAttributes r = (id :: String | r)
+element            stroke | strokeEnd | strokeJoin | fill  | font  | marker
+circle                X   |     -     |     -      |   X   |   -   |    X
+ellipse               X   |     -     |     -      |   X   |   -   |    X
+line                  X   |     X     |     -      |   -   |   -   |    X
+path                  X   |     X     |     X      |   X   |   -   |    X
+rect                  X   |     -     |     X      |   X   |   -   |    X
+text                  X   |     X     |     X      |   X   |   X   |    -
+svg                   C   |     C     |     C      |   C   |   C   |    C
+g                     C   |     C     |     C      |   C   |   C   |    C
+marker                C   |     C     |     C      |   C   |   C   |    C
+foreignObject         C   |     C     |     C      |   C   |   C   |    C
 
-type StyleAttributes r = ("class" :: String | r)
+X indicates that the collection of attributes applies to that element
+- indicates that the collection of attributes does not apply to that element
+C indicates that the collection of attributes does not apply to that element
+  but may apply to a child element and hence can still be set
+-}
+
+-- These core attributes are applicable to every element
+type CoreAttributes r = (id :: String, "class" :: String | r)
 
 -- Subset of events that work on Firefox 60/Chromium 66
 type GlobalEventAttributes r =
@@ -26,10 +49,36 @@ type GlobalEventAttributes r =
   , onMouseOver :: MouseEvent
   , onMouseUp :: MouseEvent
   , onWheel :: WheelEvent
-  | r)
+  | r
+  )
 
--- These can also be done with CSS
-type PresentationAttributes r = (stroke :: String, fill :: String | r)
+type GlobalAttributes r = GlobalEventAttributes (CoreAttributes r)
+
+-- Presentation attributes, grouped by applicability (see table above) ---------
+type StrokeAttributes r =
+  ( stroke :: String
+  , strokeDasharray :: String
+  , strokeDashoffset :: Number
+  , strokeOpacity :: Number
+  | r
+  )
+
+type StokeEndAttributes r =
+  ( strokeLinecap :: String
+  | r
+  )
+
+type StrokeJoinAttributes r =
+  ( strokeLinejoin :: String
+  , strokeMiterlimit :: String
+  | r
+  )
+
+type FillAttributes r =
+  ( fill :: String
+  , fillOpacity :: Number
+  | r
+  )
 
 type MarkerAttributes r =
   ( markerStart :: String
@@ -38,82 +87,167 @@ type MarkerAttributes r =
   | r
   )
 
-type GlobalAttributes r = (PresentationAttributes (GlobalEventAttributes (StyleAttributes (CoreAttributes r))))
-
-type SVGsvg = GlobalAttributes
-  ( width :: Number
-  , height :: Number
-  , viewBox :: String
-  , preserveAspectRatio :: String
+type FontAttributes r =
+  ( fontFamily :: String
+  , fontSize :: String
+  , fontSizeAdjust :: Number
+  , fontStretch :: String
+  , fontStyle :: String
+  , fontVariant :: String
+  , fontWeight :: String
+  | r
   )
 
-type SVGcircle = GlobalAttributes
-  ( cx :: Number
-  , cy :: Number
-  , r :: Number
-  , transform :: String
-  )
+type AllPresentationAttributes r
+  = StrokeAttributes
+      ( StrokeJoinAttributes
+          ( StokeEndAttributes
+              ( FillAttributes
+                  ( FontAttributes
+                      ( MarkerAttributes r
+                      )
+                  )
+              )
+          )
+      )
 
-type SVGellipse = GlobalAttributes
-  ( cx :: Number
-  , cy :: Number
-  , rx :: Number
-  , ry :: Number
-  , transform :: String
-  )
+-- Specific SVG elements -------------------------------------------------------
+type SVGsvg
+  = GlobalAttributes
+      ( AllPresentationAttributes
+          ( width :: Number
+          , height :: Number
+          , viewBox :: String
+          , preserveAspectRatio :: String
+          )
+      )
 
-type SVGrect = GlobalAttributes
-  ( x :: Number
-  , y :: Number
-  , rx :: Number
-  , ry :: Number
-  , width :: Number
-  , height :: Number
-  , transform :: String
-  )
+type SVGg
+  = GlobalAttributes
+      ( AllPresentationAttributes
+          ( transform :: String )
+      )
 
-type SVGg = GlobalAttributes
-  ( transform :: String )
+type SVGforeignObject
+  = GlobalAttributes
+      ( AllPresentationAttributes
+          ( x :: Number
+          , y :: Number
+          , height :: Number
+          , width :: Number
+          )
+      )
 
-type SVGpath = MarkerAttributes (GlobalAttributes
-  ( d :: String
-  , transform :: String
-  ))
+type SVGmarker
+  = GlobalAttributes
+      ( AllPresentationAttributes
+          ( markerWidth :: Number
+          , markerHeight :: Number
+          , strokeWidth :: Number
+          , refX :: Number
+          , refY :: Number
+          , orient :: String
+          , markerUnits :: String
+          )
+      )
 
-type SVGline = MarkerAttributes (GlobalAttributes
-  ( x1 :: Number
-  , y1 :: Number
-  , x2 :: Number
-  , y2 :: Number
-  , transform :: String
-  , strokeWidth :: Number
-  ))
+type SVGcircle
+  = GlobalAttributes
+      ( StrokeAttributes
+          ( FillAttributes
+              ( MarkerAttributes
+                  ( cx :: Number
+                  , cy :: Number
+                  , r :: Number
+                  , transform :: String
+                  )
+              )
+          )
+      )
 
-type SVGtext = GlobalAttributes
-  ( x :: Number
-  , y :: Number
-  , text_anchor :: String
-  , dominant_baseline :: String
-  , transform :: String
-  , font_size :: String
-  )
+type SVGellipse
+  = GlobalAttributes
+      ( StrokeAttributes
+          ( FillAttributes
+              ( MarkerAttributes
+                  ( cx :: Number
+                  , cy :: Number
+                  , rx :: Number
+                  , ry :: Number
+                  , transform :: String
+                  )
+              )
+          )
+      )
 
-type SVGforeignObject = GlobalAttributes
-  ( x :: Number
-  , y :: Number
-  , height :: Number
-  , width :: Number
-  )
+type SVGline
+  = GlobalAttributes
+      ( StrokeAttributes
+          ( StokeEndAttributes
+              ( MarkerAttributes
+                  ( x1 :: Number
+                  , y1 :: Number
+                  , x2 :: Number
+                  , y2 :: Number
+                  , transform :: String
+                  )
+              )
+          )
+      )
 
-type SVGmarker = (PresentationAttributes (StyleAttributes (CoreAttributes
-  ( markerWidth :: Number
-  , markerHeight :: Number
-  , strokeWidth :: Number
-  , refX :: Number
-  , refY :: Number
-  , orient :: String
-  , markerUnits :: String
-  ))))
+type SVGpath
+  = GlobalAttributes
+      ( StrokeAttributes
+          ( StokeEndAttributes
+              ( StrokeJoinAttributes
+                  ( FillAttributes
+                      ( MarkerAttributes
+                          ( d :: String
+                          , transform :: String
+                          )
+                      )
+                  )
+              )
+          )
+      )
+
+type SVGrect
+  = GlobalAttributes
+      ( StrokeAttributes
+          ( StrokeJoinAttributes
+              ( FillAttributes
+                  ( MarkerAttributes
+                      ( x :: Number
+                      , y :: Number
+                      , rx :: Number
+                      , ry :: Number
+                      , width :: Number
+                      , height :: Number
+                      , transform :: String
+                      )
+                  )
+              )
+          )
+      )
+
+type SVGtext
+  = GlobalAttributes
+      ( StrokeAttributes
+          ( StokeEndAttributes
+              ( StrokeJoinAttributes
+                  ( FillAttributes
+                      ( FontAttributes
+                          ( x :: Number
+                          , y :: Number
+                          , text_anchor :: String
+                          , dominant_baseline :: String
+                          , transform :: String
+                          )
+                      )
+                  )
+              )
+          )
+      )
 
 --------------------------------------------------------------------------------
 

--- a/src/Halogen/Svg/Indexed.purs
+++ b/src/Halogen/Svg/Indexed.purs
@@ -60,6 +60,7 @@ type StrokeAttributes r =
   , strokeDasharray :: String
   , strokeDashoffset :: Number
   , strokeOpacity :: Number
+  , strokeWidth :: Number
   | r
   )
 

--- a/src/Halogen/Svg/Indexed.purs
+++ b/src/Halogen/Svg/Indexed.purs
@@ -1,5 +1,6 @@
 module Halogen.Svg.Indexed where
 
+import Type.Row (type (+))
 import Web.UIEvent.KeyboardEvent (KeyboardEvent)
 import Web.UIEvent.MouseEvent (MouseEvent)
 import Web.UIEvent.WheelEvent (WheelEvent)
@@ -31,7 +32,7 @@ C indicates that the collection of attributes does not apply to that element
 -}
 
 -- These core attributes are applicable to every element
-type CoreAttributes r = (id :: String, "class" :: String | r)
+type CoreAttributes r = ( id :: String, "class" :: String | r)
 
 -- Subset of events that work on Firefox 60/Chromium 66
 type GlobalEventAttributes r =
@@ -52,7 +53,7 @@ type GlobalEventAttributes r =
   | r
   )
 
-type GlobalAttributes r = GlobalEventAttributes (CoreAttributes r)
+type GlobalAttributes r = CoreAttributes + GlobalEventAttributes + r
 
 -- Presentation attributes, grouped by applicability (see table above) ---------
 type StrokeAttributes r =
@@ -89,166 +90,106 @@ type MarkerAttributes r =
   )
 
 type FontAttributes r =
-  ( fontFamily :: String
-  , fontSize :: String
-  , fontSizeAdjust :: Number
-  , fontStretch :: String
-  , fontStyle :: String
-  , fontVariant :: String
-  , fontWeight :: String
+  ( font_family :: String
+  , font_size :: String
+  , font_sizeAdjust :: Number
+  , font_stretch :: String
+  , font_style :: String
+  , font_variant :: String
+  , font_weight :: String
   | r
   )
 
 type AllPresentationAttributes r
-  = StrokeAttributes
-      ( StrokeJoinAttributes
-          ( StokeEndAttributes
-              ( FillAttributes
-                  ( FontAttributes
-                      ( MarkerAttributes r
-                      )
-                  )
-              )
-          )
-      )
+  = StrokeAttributes + StrokeJoinAttributes + StokeEndAttributes
+  + FillAttributes + FontAttributes + MarkerAttributes + r
 
 -- Specific SVG elements -------------------------------------------------------
 type SVGsvg
-  = GlobalAttributes
-      ( AllPresentationAttributes
-          ( width :: Number
-          , height :: Number
-          , viewBox :: String
-          , preserveAspectRatio :: String
-          )
-      )
+  = GlobalAttributes + AllPresentationAttributes
+  + ( width :: Number
+    , height :: Number
+    , viewBox :: String
+    , preserveAspectRatio :: String
+    )
 
 type SVGg
-  = GlobalAttributes
-      ( AllPresentationAttributes
-          ( transform :: String )
-      )
+  = GlobalAttributes + AllPresentationAttributes
+  + ( transform :: String )
 
 type SVGforeignObject
-  = GlobalAttributes
-      ( AllPresentationAttributes
-          ( x :: Number
-          , y :: Number
-          , height :: Number
-          , width :: Number
-          )
-      )
+  = GlobalAttributes + AllPresentationAttributes
+  + ( x :: Number
+    , y :: Number
+    , height :: Number
+    , width :: Number
+    )
 
 type SVGmarker
-  = GlobalAttributes
-      ( AllPresentationAttributes
-          ( markerWidth :: Number
-          , markerHeight :: Number
-          , strokeWidth :: Number
-          , refX :: Number
-          , refY :: Number
-          , orient :: String
-          , markerUnits :: String
-          )
-      )
+  = GlobalAttributes + AllPresentationAttributes
+  + ( markerWidth :: Number
+    , markerHeight :: Number
+    , strokeWidth :: Number
+    , refX :: Number
+    , refY :: Number
+    , orient :: String
+    , markerUnits :: String
+    )
 
 type SVGcircle
-  = GlobalAttributes
-      ( StrokeAttributes
-          ( FillAttributes
-              ( MarkerAttributes
-                  ( cx :: Number
-                  , cy :: Number
-                  , r :: Number
-                  , transform :: String
-                  )
-              )
-          )
-      )
+  = GlobalAttributes + StrokeAttributes + FillAttributes + MarkerAttributes
+  + ( cx :: Number
+    , cy :: Number
+    , r :: Number
+    , transform :: String
+    )
 
 type SVGellipse
-  = GlobalAttributes
-      ( StrokeAttributes
-          ( FillAttributes
-              ( MarkerAttributes
-                  ( cx :: Number
-                  , cy :: Number
-                  , rx :: Number
-                  , ry :: Number
-                  , transform :: String
-                  )
-              )
-          )
-      )
+  = GlobalAttributes + StrokeAttributes + FillAttributes + MarkerAttributes
+  + ( cx :: Number
+    , cy :: Number
+    , rx :: Number
+    , ry :: Number
+    , transform :: String
+    )
 
 type SVGline
-  = GlobalAttributes
-      ( StrokeAttributes
-          ( StokeEndAttributes
-              ( MarkerAttributes
-                  ( x1 :: Number
-                  , y1 :: Number
-                  , x2 :: Number
-                  , y2 :: Number
-                  , transform :: String
-                  )
-              )
-          )
-      )
+  = GlobalAttributes + StrokeAttributes + StokeEndAttributes + MarkerAttributes
+  + ( x1 :: Number
+    , y1 :: Number
+    , x2 :: Number
+    , y2 :: Number
+    , transform :: String
+    )
 
 type SVGpath
-  = GlobalAttributes
-      ( StrokeAttributes
-          ( StokeEndAttributes
-              ( StrokeJoinAttributes
-                  ( FillAttributes
-                      ( MarkerAttributes
-                          ( d :: String
-                          , transform :: String
-                          )
-                      )
-                  )
-              )
-          )
-      )
+  = GlobalAttributes + StrokeAttributes + StokeEndAttributes
+  + StrokeJoinAttributes + FillAttributes + MarkerAttributes
+  + ( d :: String
+    , transform :: String
+    )
 
 type SVGrect
-  = GlobalAttributes
-      ( StrokeAttributes
-          ( StrokeJoinAttributes
-              ( FillAttributes
-                  ( MarkerAttributes
-                      ( x :: Number
-                      , y :: Number
-                      , rx :: Number
-                      , ry :: Number
-                      , width :: Number
-                      , height :: Number
-                      , transform :: String
-                      )
-                  )
-              )
-          )
-      )
+  = GlobalAttributes + StrokeAttributes + StrokeJoinAttributes
+  + FillAttributes + MarkerAttributes
+  + ( x :: Number
+    , y :: Number
+    , rx :: Number
+    , ry :: Number
+    , width :: Number
+    , height :: Number
+    , transform :: String
+    )
 
 type SVGtext
-  = GlobalAttributes
-      ( StrokeAttributes
-          ( StokeEndAttributes
-              ( StrokeJoinAttributes
-                  ( FillAttributes
-                      ( FontAttributes
-                          ( x :: Number
-                          , y :: Number
-                          , text_anchor :: String
-                          , dominant_baseline :: String
-                          , transform :: String
-                          )
-                      )
-                  )
-              )
-          )
-      )
+  = GlobalAttributes + StrokeAttributes + StokeEndAttributes
+  + StrokeJoinAttributes + FillAttributes + FontAttributes
+  + ( x :: Number
+    , y :: Number
+    , text_anchor :: String
+    , dominant_baseline :: String
+    , transform :: String
+    )
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
spago 0.20.0 had a breaking change that prohibits source files from directly importing transitive dependencies. This PR fixes the error that occurs when trying to build under versions of spago later than or equal to 0.20.0.