### PR TITLE
Fix repeatCount does not support 'indefinite'.

### DIFF
--- a/src/Halogen/Svg/Attributes.purs
+++ b/src/Halogen/Svg/Attributes.purs
@@ -259,8 +259,8 @@ refX = attr (H.AttrName "refX") <<< show
 refY :: forall r i. Number -> IProp (refY :: Number | r) i
 refY = attr (H.AttrName "refY") <<< show
 
-repeatCount :: forall r i. Int -> IProp (repeatCount :: Int | r) i
-repeatCount = attr (H.AttrName "repeatCount") <<< show
+repeatCount :: forall r i. String -> IProp (repeatCount :: String | r) i
+repeatCount = attr (H.AttrName "repeatCount")
 
 rx :: forall r i. Number -> IProp (rx :: Number | r) i
 rx = attr (H.AttrName "rx") <<< show

--- a/src/Halogen/Svg/Indexed.purs
+++ b/src/Halogen/Svg/Indexed.purs
@@ -295,7 +295,7 @@ type AnimationAttributes r = GlobalAttributes
   , to :: String
   , begin :: String
   , dur :: String
-  , repeatCount :: Int
+  , repeatCount :: String
   , fill :: String
   | r
   )


### PR DESCRIPTION
This changes the type of `repeatCount` to `String`, allowing use of `indefinite`.

Fixes:  SVG animation repeatCount should accept "indefinite" #37 